### PR TITLE
Handle unrecognized column typ

### DIFF
--- a/src/client/compiler/parser/SQLTable.ts
+++ b/src/client/compiler/parser/SQLTable.ts
@@ -47,6 +47,11 @@ export class Column {
             type = new SQLDerivedType(<SQLBaseType>type, parameterValues);
         }
 
+        // If type is unrecognized default to type text.
+        if (!type) {
+            type = SQLBaseType.getBaseType('text');
+        }
+
         let column = new Column(cs.name, type, table, cs.isPrimaryKey, !cs.isPrimaryKey, cs.defaultValue, cs.isAutoIncrement);
         column.notNull = cs.notNull;
         


### PR DESCRIPTION
When the type of a column is unrecognized, assign the type 'text' to this column.

Explanation: SQLite allows column types to be (almost) arbitrary strings. While the SQL-IDE allows only a fixed set of types when creating tables within the SQL-IDE, it is still possible to have tables with 'exotic' types by importing them. This results in an undefined column type. When you run a select-query on such a table, the application 'crashes' at line 502 of ResultsetPresenter.ts and no result table is shown.

Suggested Solution: If the column type is unrecognized, let it default to the type 'text'.

Note: The aim is to get a working database from all import-files that work in sqlite. I am not sure whether defaulting to `text` is the best solution. It is just a quick fix.